### PR TITLE
Updating docs to include adding config for AclManager.models

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Download the .zip or .tar.gz file, unzip and rename the plugin folder "cakephp3-
 
 ```php
 # Example configuration for an schema based on Groups, Roles and Users
+Configure::write('AclManager.models', array('Groups', 'Roles', 'Users'));
 Configure::write('AclManager.aros', array('Groups', 'Roles', 'Users'));
 
 Plugin::load('Acl', ['bootstrap' => true]);


### PR DESCRIPTION
bin/cake acl_extras aco_sync will produce errors if the models are not defined in the Config: 

Call to a member function alias() on boolean in [D:\projects\cakephp3-aclmanager-test\vendor\ivanamat\cakephp3-aclmanager\src\Controller\AclController.php, line 90]