### PR TITLE
updating version requirement to ~1.0 for latest cakephp/plugin-ins…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4.16",
         "composer/installers": "*",
         "cakephp/cakephp": "~3.0",
-        "cakephp/plugin-installer": "~0.0",
+        "cakephp/plugin-installer": "~1.0",
         "cakephp/acl": "~0.2"
     },
     "autoload": {


### PR DESCRIPTION
…taller

I forked, updated & tested on a fresh install of cakephp/app and no issues.  You can repeat & confirm by adding my forked version as a VCS repo to composer to a fresh install of cakephp/app:

    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/pfuri/cakephp3-aclmanager"
        }
    ]